### PR TITLE
feat: add Firebase Storage image upload for Trip Locations (Fixes #14)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'firebasestorage.googleapis.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
   env: {

--- a/src/app/trips/new/page.tsx
+++ b/src/app/trips/new/page.tsx
@@ -40,6 +40,8 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/context/auth-context';
 import { useFirestore } from '@/firebase';
 import { addDoc, collection, doc, updateDoc, Timestamp } from 'firebase/firestore';
+import { useFirebaseApp } from '@/firebase';
+import { getStorage, ref, uploadBytesResumable, getDownloadURL } from 'firebase/storage';
 import { Textarea } from '@/components/ui/textarea';
 
 const formSchema = z.object({
@@ -68,6 +70,10 @@ export default function NewTripPage() {
   const [step, setStep] = useState(1);
   const { user } = useAuth();
   const firestore = useFirestore();
+  const firebaseApp = useFirebaseApp();
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [isUploading, setIsUploading] = useState(false);
   
   const destinationParam = searchParams.get('destination');
 
@@ -127,6 +133,40 @@ export default function NewTripPage() {
 
       const docRef = await addDoc(tripsCollection, newTripData);
 
+      if (imageFile) {
+        setIsUploading(true);
+        toast({
+          title: 'Uploading image...',
+          description: 'Saving your destination photo.',
+        });
+        const storage = getStorage(firebaseApp);
+        const storageRef = ref(storage, `trips/${docRef.id}/${imageFile.name}`);
+        const uploadTask = uploadBytesResumable(storageRef, imageFile);
+        
+        uploadTask.on(
+          'state_changed',
+          (snapshot) => {
+            const progress = snapshot.totalBytes > 0 ? (snapshot.bytesTransferred / snapshot.totalBytes) * 100 : 0;
+            setUploadProgress(progress);
+          }
+        );
+
+        try {
+          await uploadTask;
+          const downloadURL = await getDownloadURL(uploadTask.snapshot.ref);
+          await updateDoc(doc(firestore, 'trips', docRef.id), { imageUrl: downloadURL });
+        } catch (uploadError) {
+          console.error("Image upload failed:", uploadError);
+          toast({
+            variant: "destructive",
+            title: "Image Upload Failed",
+            description: "Could not upload your custom image. A default image will be used.",
+          });
+        } finally {
+          setIsUploading(false);
+        }
+      }
+
       toast({
         title: 'Creating your adventure...',
         description: 'Our AI is crafting a personalized itinerary just for you.',
@@ -168,6 +208,7 @@ export default function NewTripPage() {
         title: 'Creation Failed',
         description: 'Something went wrong while saving your trip. Please try again.',
       });
+      setIsUploading(false);
       setIsGenerating(false);
     } 
   };
@@ -290,6 +331,20 @@ export default function NewTripPage() {
                             <FormMessage />
                           </FormItem>
                         )}
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <FormLabel className="text-foreground/80">Cover Image (Optional)</FormLabel>
+                      <Input 
+                        type="file" 
+                        accept="image/*" 
+                        onChange={(e) => {
+                          if (e.target.files && e.target.files[0]) {
+                            setImageFile(e.target.files[0]);
+                          }
+                        }}
+                        className="bg-background/50 border-border/50 focus:border-primary/50 transition-colors cursor-pointer"
                       />
                     </div>
 
@@ -551,10 +606,14 @@ export default function NewTripPage() {
                   ) : (
                     <Button 
                       type="submit" 
-                      disabled={isGenerating}
+                      disabled={isGenerating || isUploading}
                       className="min-w-[200px] gap-2 bg-gradient-to-r from-primary to-[#6c63ff] hover:opacity-90 shadow-xl shadow-primary/20 transition-all duration-300 ease-in-out hover:scale-105 active:scale-95"
                     >
-                      {isGenerating ? (
+                      {isUploading ? (
+                        <>
+                          <Loader2 className="w-4 h-4 animate-spin" /> Uploading {Math.round(uploadProgress)}%
+                        </>
+                      ) : isGenerating ? (
                         <>
                           <Loader2 className="w-4 h-4 animate-spin" /> Generating...
                         </>

--- a/src/firebase/config.ts
+++ b/src/firebase/config.ts
@@ -4,6 +4,7 @@ export const firebaseConfig = {
   "apiKey": "AIzaSyAYJXBieKBe4u17ZxFXMWJ0ReqYtViKs3U",
   "authDomain": "studio-2601630665-592d2.firebaseapp.com",
   "measurementId": "",
-  "messagingSenderId": "975009106470"
+  "messagingSenderId": "975009106470",
+  "storageBucket": "studio-2601630665-592d2.appspot.com"
 };
 


### PR DESCRIPTION
Resolves #14 

### Description
This PR implements the ability for users to upload custom images for their trip locations using Firebase Storage during the trip creation flow. 

**Changes Include:**
- **Next.js Config**: Added `firebasestorage.googleapis.com` to `remotePatterns` in `next.config.ts` to allow the Next.js `<Image>` component to render the uploaded storage URLs properly.
- **Firebase Config**: Initialized the `storageBucket` property in `src/firebase/config.ts`.
- **Trip Creation UI**: Added a sleek file input field to the Details step of the `NewTripPage` wizard.
- **Upload Logic**: Integrated `uploadBytesResumable` to handle file uploads to Firebase Storage with an integrated loading spinner. The upload logic incorporates robust error handling so that if an upload fails (e.g., due to CORS or permission errors), the application gracefully falls back to the default Unsplash image without blocking the rest of the itinerary generation.

### ⚠️ Important Note for Maintainers (Action Required)
For image uploads to work successfully from the web browser environment, **Firebase Storage CORS must be explicitly configured.** Without this, uploads from `localhost` or the production domain will be blocked.

To allow the web uploads, the admin of the Firebase project (`studio-2601630665-592d2`) simply needs to run the following via their Google Cloud Console Shell:
```bash
echo '[{"origin": ["*"],"method": ["GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS"],"maxAgeSeconds": 3600,"responseHeader": ["*"]}]' > cors.json
gsutil cors set cors.json gs://studio-2601630665-592d2.appspot.com
